### PR TITLE
 Feature - disactive tab at fight arena

### DIFF
--- a/src/pages/AppHeader.tsx
+++ b/src/pages/AppHeader.tsx
@@ -4,6 +4,7 @@ import { GenericButton } from "@/design-system/generic-componenets/GenericButton
 import { GenericTab, type TabItem } from "@/design-system/generic-componenets/GenericTab";
 import { usePokemonsData } from "@/hooks/usePokemonsData";
 import { ChoosePokemonBattlePanel } from "./home-page/ChoosePokemonBattlePanel";
+import { useNavigate } from "react-router-dom";
 
 const headerTabs: TabItem[] = [
   { label: "All Pokemons", value: "all pokemons" },
@@ -13,11 +14,12 @@ const headerTabs: TabItem[] = [
 export interface AppHeaderProps {
   activeTab: string;
   onTabChange: (val: string) => void;
+  isFightArena: boolean;
 }
 
-export const AppHeader: React.FC<AppHeaderProps> = ({ activeTab, onTabChange }) => {
+export const AppHeader: React.FC<AppHeaderProps> = ({ activeTab, onTabChange, isFightArena }) => {
   const [isBattleOpen, setBattleOpen] = useState(false);
-
+  const navigate = useNavigate();
   
   const { pokemons: myPokemons } = usePokemonsData({
     showMyPokemons: true,
@@ -33,6 +35,13 @@ export const AppHeader: React.FC<AppHeaderProps> = ({ activeTab, onTabChange }) 
     rowsPerPage: 1000,
   });
 
+  const handleTabChange = (val: string) => {
+    if (isFightArena) {
+      navigate("/home-page");
+    }
+    onTabChange(val);
+  };
+
   return (
     <>
       <header className="fixed inset-x-0 top-0 h-20 z-20 bg-white">
@@ -43,7 +52,7 @@ export const AppHeader: React.FC<AppHeaderProps> = ({ activeTab, onTabChange }) 
               variant="primaryTab"
               tabs={headerTabs}
               value={activeTab}
-              onValueChange={onTabChange}
+              onValueChange={handleTabChange}
             />
           </div>
           <GenericButton
@@ -51,6 +60,7 @@ export const AppHeader: React.FC<AppHeaderProps> = ({ activeTab, onTabChange }) 
             size="small"
             text="Start a Fight"
             onClick={() => setBattleOpen(true)}
+            disabled={isFightArena}
           />
         </div>
       </header>

--- a/src/pages/AppLayout.tsx
+++ b/src/pages/AppLayout.tsx
@@ -1,9 +1,23 @@
-import { useState } from "react";
-import { Outlet } from "react-router-dom";
+import { useState, useEffect } from "react";
+import { Outlet, useLocation, matchPath } from "react-router-dom";
 import { AppHeader } from "./AppHeader";
 
 export function AppLayout() {
   const [activeTab, setActiveTab] = useState("all pokemons");
+
+  const location = useLocation();
+  const isFightArena = !!matchPath("/fighting-arena-page", location.pathname);
+
+  //whenever we enter or leave the arena, clear or reset the tab
+  useEffect(() => {
+    if (isFightArena) {
+      setActiveTab("");          
+    } else if (!activeTab) {
+      //if we just left the arena, default back to All Pokemons
+      setActiveTab("all pokemons");
+    }
+  }, [isFightArena]);
+
   const showMyPokemons = activeTab === "my pokemons";
 
   return (
@@ -11,8 +25,9 @@ export function AppLayout() {
       <AppHeader
         activeTab={activeTab}
         onTabChange={setActiveTab}
-      />                  
-      <main className="flex-1 pt-16"> 
+        isFightArena={isFightArena}
+      />
+      <main className="flex-1 pt-16">
         <Outlet context={{ showMyPokemons }} />
       </main>
     </div>


### PR DESCRIPTION
Set the filter tab - my/all pokemons to empty (not selected) when the user is on the fighting arena page.